### PR TITLE
Fix for #914 Extension Value fields in ExtensionList objects exceeding the size limit of 128 (#44)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quoting-service",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -94,9 +94,9 @@
       }
     },
     "@mojaloop/central-services-error-handling": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.2.4.tgz",
-      "integrity": "sha512-tcRhFAA5wdaggelS69sTDBlMu9AA9NCElAlWsFQZQFG7xc8/lacXsBoiVQ+RjAozkDVqKcPXNyPSaWTmht0I8A==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.3.0.tgz",
+      "integrity": "sha512-LSqQkI2/2BI7EukrWgOFafk1rBkxrwgNDfJ1NQ1ZqvsJ5/Xuapd2rJbRi2mik5bfjObU43+GBEzWBqIGnZpksQ==",
       "requires": {
         "@modusbox/mojaloop-sdk-standard-components": "0.0.37",
         "@mojaloop/central-services-shared": "6.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "quoting-service",
   "description": "Quoting Service hosted by a scheme",
   "license": "Apache-2.0",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "author": "Modusbox",
   "contributors": [
     "James Bush <james.bush@modusbox.com>",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@hapi/good": "8.2.0",
-    "@mojaloop/central-services-error-handling": "7.2.4",
+    "@mojaloop/central-services-error-handling": "7.3.0",
     "axios": "0.19.0",
     "blipp": "4.0.0",
     "good-console": "8.0.0",


### PR DESCRIPTION
- Updated central-services-error-handling lib to 7.3.0 with bugfix
