### PR TITLE
Commented out the function getParticipantEndpoint in cachedDatabase

### DIFF
--- a/src/data/cachedDatabase.js
+++ b/src/data/cachedDatabase.js
@@ -93,9 +93,9 @@ class CachedDatabase extends Database {
     return this.getCacheValue('getLedgerEntryType', [name])
   }
 
-  async getParticipantEndpoint (participantName, endpointType) {
-    return this.getCacheValue('getParticipantEndpoint', [participantName, endpointType])
-  }
+  // async getParticipantEndpoint (participantName, endpointType) {
+  //  return this.getCacheValue('getParticipantEndpoint', [participantName, endpointType])
+  // }
 
   async getCacheValue (type, params) {
     try {


### PR DESCRIPTION
While testing the bugfix #998, encountered a problem related to caching.

The change in party endpoints is not getting reflected for the following quote requests immediately. This is due to caching on getParticipantEndpoint function.
I discussed with Sam, he suggested to disable the caching on that function; to be followed-up in mojaloop/project/issues/1025