### PR TITLE
Add ISO test currencies (XTS, XXX)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "quoting-service",
   "description": "Quoting Service hosted by a scheme",
   "license": "Apache-2.0",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "author": "ModusBox",
   "contributors": [
     "James Bush <james.bush@modusbox.com>",

--- a/src/interface/QuotingService-swagger.yaml
+++ b/src/interface/QuotingService-swagger.yaml
@@ -746,6 +746,8 @@ components:
         - XDR
         - XOF
         - XPF
+        - XTS
+        - XXX
         - YER
         - ZAR
         - ZMW

--- a/src/interface/swagger.json
+++ b/src/interface/swagger.json
@@ -1311,6 +1311,8 @@
         "XDR",
         "XOF",
         "XPF",
+        "XTS",
+        "XXX",
         "YER",
         "ZAR",
         "ZMW",


### PR DESCRIPTION
Adding two ISO-4217 test currencies (XTS and XXX) to enable testing in production environments without the need to use live currencies.