### PR TITLE
[1385] validate dfsps in payload for simple routing mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quoting-service",
-  "version": "11.1.5",
+  "version": "11.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "quoting-service",
   "description": "Quoting Service hosted by a scheme",
   "license": "Apache-2.0",
-  "version": "11.1.5",
+  "version": "11.2.0",
   "author": "ModusBox",
   "contributors": [
     "James Bush <james.bush@modusbox.com>",

--- a/src/model/quotes.js
+++ b/src/model/quotes.js
@@ -148,6 +148,7 @@ class QuotesModel {
    * @returns {promise} - promise will reject if request is not valid
    */
   async validateQuoteRequest (fspiopSource, fspiopDestination, quoteRequest) {
+    const envConfig = new Config()
     // note that the framework should validate the form of the request
     // here we can do some hard-coded rule validations to ensure requests
     // do not lead to unsupported scenarios or use-cases.
@@ -165,6 +166,12 @@ class QuotesModel {
 
     await this.db.getParticipant(fspiopSource, LOCAL_ENUM.PAYER_DFSP, quoteRequest.amount.currency, ENUM.Accounts.LedgerAccountType.POSITION)
     await this.db.getParticipant(fspiopDestination, LOCAL_ENUM.PAYEE_DFSP, quoteRequest.amount.currency, ENUM.Accounts.LedgerAccountType.POSITION)
+
+    // Following is the validation to make sure valid fsp's are used in the payload for simple routing mode
+    if (envConfig.simpleRoutingMode) {
+      await this.db.getParticipant(quoteRequest.payer.partyIdInfo.fspId, LOCAL_ENUM.PAYER_DFSP, quoteRequest.amount.currency, ENUM.Accounts.LedgerAccountType.POSITION)
+      await this.db.getParticipant(quoteRequest.payee.partyIdInfo.fspId, LOCAL_ENUM.PAYEE_DFSP, quoteRequest.amount.currency, ENUM.Accounts.LedgerAccountType.POSITION)
+    }
   }
 
   /**

--- a/test/unit/model/quotes.test.js
+++ b/test/unit/model/quotes.test.js
@@ -613,7 +613,11 @@ describe('QuotesModel', () => {
       await quotesModel.validateQuoteRequest(fspiopSource, fspiopDestination, mockData.quoteRequest)
 
       expect(quotesModel.db).toBeTruthy() // Constructor should have been called
-      expect(quotesModel.db.getParticipant).toHaveBeenCalledTimes(2)
+      if (mockConfig.simpleRoutingMode) {
+        expect(quotesModel.db.getParticipant).toHaveBeenCalledTimes(4)
+      } else {
+        expect(quotesModel.db.getParticipant).toHaveBeenCalledTimes(2)
+      }
       expect(quotesModel.db.getParticipant.mock.calls[0][0]).toBe(fspiopSource)
       expect(quotesModel.db.getParticipant.mock.calls[1][0]).toBe(fspiopDestination)
     })


### PR DESCRIPTION
### Summary
There is no validation of the DFSPs in the payload when simple routing mode is used. Added a check to make sure valid dfsps are being sent in the request.