### PR TITLE
fix: handle unhandled promise rejections

### DIFF
--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -199,6 +199,41 @@
       "decision": "ignore",
       "madeAt": 1654706048509,
       "expiresAt": 1657297987895
+    },
+    "1070483|@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>protobufjs": {
+      "decision": "ignore",
+      "madeAt": 1655225692518,
+      "expiresAt": 1657817682182
+    },
+    "1070483|@mojaloop/event-sdk>grpc>protobufjs": {
+      "decision": "ignore",
+      "madeAt": 1655225692519,
+      "expiresAt": 1657817682182
+    },
+    "1070030|@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>protobufjs>shins>markdown-it": {
+      "decision": "ignore",
+      "madeAt": 1655225694300,
+      "expiresAt": 1657817682182
+    },
+    "1070030|widdershins>markdown-it": {
+      "decision": "ignore",
+      "madeAt": 1655225694300,
+      "expiresAt": 1657817682182
+    },
+    "1068155|@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>protobufjs>shins>markdown-it>sanitize-html": {
+      "decision": "ignore",
+      "madeAt": 1655225696500,
+      "expiresAt": 1657817682182
+    },
+    "1070260|@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>protobufjs>shins>markdown-it>sanitize-html": {
+      "decision": "ignore",
+      "madeAt": 1655225697618,
+      "expiresAt": 1657817682182
+    },
+    "1068310|widdershins>markdown-it>yargs>yargs-parser": {
+      "decision": "ignore",
+      "madeAt": 1655225698689,
+      "expiresAt": 1657817682182
     }
   },
   "rules": {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "jest": "28.1.1",
         "jest-junit": "13.2.0",
         "npm-audit-resolver": "3.0.0-7",
-        "npm-check-updates": "13.1.2",
+        "npm-check-updates": "13.1.5",
         "nyc": "15.1.0",
         "pre-commit": "1.2.2",
         "proxyquire": "2.1.3",
@@ -10236,9 +10236,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-13.1.2.tgz",
-      "integrity": "sha512-ZXfXEoqqMnDNuR2LNLXBsNPTRCvo5JcH+Wo6YoSAh5EYcPqKzTkRSPB82ujPTbIEU7BtrwXbx3p2Y+IXK3dmdA==",
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-13.1.5.tgz",
+      "integrity": "sha512-vAVYlrrxJIPH/R5mxMzrNwP33hYflvk7oQqPjPOySCavCFwhXKmfK5sn/rogyebg7cLnECiDxsczGqvTOEBRAA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -23845,9 +23845,9 @@
       }
     },
     "npm-check-updates": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-13.1.2.tgz",
-      "integrity": "sha512-ZXfXEoqqMnDNuR2LNLXBsNPTRCvo5JcH+Wo6YoSAh5EYcPqKzTkRSPB82ujPTbIEU7BtrwXbx3p2Y+IXK3dmdA==",
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-13.1.5.tgz",
+      "integrity": "sha512-vAVYlrrxJIPH/R5mxMzrNwP33hYflvk7oQqPjPOySCavCFwhXKmfK5sn/rogyebg7cLnECiDxsczGqvTOEBRAA==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "jest": "28.1.1",
     "jest-junit": "13.2.0",
     "npm-audit-resolver": "3.0.0-7",
-    "npm-check-updates": "13.1.2",
+    "npm-check-updates": "13.1.5",
     "nyc": "15.1.0",
     "pre-commit": "1.2.2",
     "proxyquire": "2.1.3",

--- a/src/handlers/bulkQuotes.js
+++ b/src/handlers/bulkQuotes.js
@@ -76,7 +76,9 @@ module.exports = {
       }, EventSdk.AuditEventAction.start)
 
       // call the quote request handler in the model
-      model.handleBulkQuoteRequest(request.headers, request.payload, span)
+      model.handleBulkQuoteRequest(request.headers, request.payload, span).catch(err => {
+        request.server.log(['error'], `ERROR - handleBulkQuoteRequest: ${LibUtil.getStackOrInspect(err)}`)
+      })
     } catch (err) {
       // something went wrong, use the model to handle the error in a sensible way
       request.server.log(['error'], `ERROR - POST /bulkQuotes: ${LibUtil.getStackOrInspect(err)}`)

--- a/src/handlers/bulkQuotes/{id}.js
+++ b/src/handlers/bulkQuotes/{id}.js
@@ -117,7 +117,9 @@ module.exports = {
         payload: request.payload
       }, EventSdk.AuditEventAction.start)
       // call the quote update handler in the model
-      model.handleBulkQuoteUpdate(request.headers, bulkQuoteId, request.payload, span)
+      model.handleBulkQuoteUpdate(request.headers, bulkQuoteId, request.payload, span).catch(err => {
+        request.server.log(['error'], `ERROR - handleBulkQuoteUpdate: ${LibUtil.getStackOrInspect(err)}`)
+      })
     } catch (err) {
       // something went wrong, use the model to handle the error in a sensible way
       request.server.log(['error'], `ERROR - PUT /bulkQuotes/{id}: ${LibUtil.getStackOrInspect(err)}`)

--- a/src/handlers/bulkQuotes/{id}.js
+++ b/src/handlers/bulkQuotes/{id}.js
@@ -74,7 +74,9 @@ module.exports = {
       // call the model to re-forward the quote update to the correct party
       // note that we do not check if our caller is the correct party, but we
       // will send the callback to the correct party regardless.
-      model.handleBulkQuoteGet(request.headers, bulkQuoteId, span)
+      model.handleBulkQuoteGet(request.headers, bulkQuoteId, span).catch(err => {
+        request.server.log(['error'], `ERROR - handleBulkQuoteGet: ${LibUtil.getStackOrInspect(err)}`)
+      })
     } catch (err) {
       // something went wrong, use the model to handle the error in a sensible way
       request.server.log(['error'], `ERROR - GET /bulkQuotes/{id}: ${LibUtil.getStackOrInspect(err)}`)

--- a/src/handlers/bulkQuotes/{id}/error.js
+++ b/src/handlers/bulkQuotes/{id}/error.js
@@ -72,7 +72,9 @@ module.exports = {
         payload: request.payload
       }, EventSdk.AuditEventAction.start)
       // call the quote error handler in the model
-      model.handleBulkQuoteError(request.headers, bulkQuoteId, request.payload.errorInformation, span)
+      model.handleBulkQuoteError(request.headers, bulkQuoteId, request.payload.errorInformation, span).catch(err => {
+        request.server.log(['error'], `ERROR - handleBulkQuoteError: ${LibUtil.getStackOrInspect(err)}`)
+      })
     } catch (err) {
       // something went wrong, use the model to handle the error in a sensible way
       request.server.log(['error'], `ERROR - PUT /bulkQuotes/{id}/error: ${LibUtil.getStackOrInspect(err)}`)

--- a/src/handlers/quotes.js
+++ b/src/handlers/quotes.js
@@ -76,7 +76,9 @@ module.exports = {
       }, EventSdk.AuditEventAction.start)
 
       // call the quote request handler in the model
-      model.handleQuoteRequest(request.headers, request.payload, span)
+      model.handleQuoteRequest(request.headers, request.payload, span).catch(err => {
+        request.server.log(['error'], `ERROR - handleQuoteRequest: ${LibUtil.getStackOrInspect(err)}`)
+      })
     } catch (err) {
       // something went wrong, use the model to handle the error in a sensible way
       request.server.log(['error'], `ERROR - POST /quotes: ${LibUtil.getStackOrInspect(err)}`)

--- a/src/handlers/quotes/{id}.js
+++ b/src/handlers/quotes/{id}.js
@@ -120,7 +120,9 @@ module.exports = {
         payload: request.payload
       }, EventSdk.AuditEventAction.start)
       // call the quote update handler in the model
-      model.handleQuoteUpdate(request.headers, quoteId, request.payload, span)
+      model.handleQuoteUpdate(request.headers, quoteId, request.payload, span).catch(err => {
+        request.server.log(['error'], `ERROR - handleQuoteUpdate: ${LibUtil.getStackOrInspect(err)}`)
+      })
     } catch (err) {
       // something went wrong, use the model to handle the error in a sensible way
       request.server.log(['error'], `ERROR - PUT /quotes/{id}: ${LibUtil.getStackOrInspect(err)}`)

--- a/src/handlers/quotes/{id}.js
+++ b/src/handlers/quotes/{id}.js
@@ -76,7 +76,9 @@ module.exports = {
       // call the model to re-forward the quote update to the correct party
       // note that we do not check if our caller is the correct party, but we
       // will send the callback to the correct party regardless.
-      model.handleQuoteGet(request.headers, quoteId, span)
+      model.handleQuoteGet(request.headers, quoteId, span).catch(err => {
+        request.server.log(['error'], `ERROR - handleQuoteGet: ${LibUtil.getStackOrInspect(err)}`)
+      })
     } catch (err) {
       // something went wrong, use the model to handle the error in a sensible way
       request.server.log(['error'], `ERROR - GET /quotes/{id}: ${LibUtil.getStackOrInspect(err)}`)

--- a/src/handlers/quotes/{id}/error.js
+++ b/src/handlers/quotes/{id}/error.js
@@ -74,7 +74,9 @@ module.exports = {
         payload: request.payload
       }, EventSdk.AuditEventAction.start)
       // call the quote error handler in the model
-      model.handleQuoteError(request.headers, quoteId, request.payload.errorInformation, span)
+      model.handleQuoteError(request.headers, quoteId, request.payload.errorInformation, span).catch(err => {
+        request.server.log(['error'], `ERROR - handleQuoteError: ${LibUtil.getStackOrInspect(err)}`)
+      })
     } catch (err) {
       // something went wrong, use the model to handle the error in a sensible way
       request.server.log(['error'], `ERROR - PUT /quotes/{id}/error: ${LibUtil.getStackOrInspect(err)}`)

--- a/test/unit/handlers/bulkQuotes.test.js
+++ b/test/unit/handlers/bulkQuotes.test.js
@@ -79,7 +79,7 @@ describe('/bulkQuotes', () => {
       // Arrange
       const handleException = jest.fn()
       BulkQuotesModel.mockImplementationOnce(() => ({
-        handleBulkQuoteRequest: () => {
+        handleBulkQuoteRequest: async () => {
           throw new Error('Create Quote Test Error')
         },
         handleException
@@ -105,8 +105,8 @@ describe('/bulkQuotes', () => {
       await BulkQuotesHandler.post(mockContext, mockRequest, handler)
 
       // Assert
+      expect(BulkQuotesModel).toHaveBeenCalledTimes(1)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.ACCEPTED.CODE)
-      expect(handleException).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/test/unit/handlers/bulkQuotes.test.js
+++ b/test/unit/handlers/bulkQuotes.test.js
@@ -77,11 +77,12 @@ describe('/bulkQuotes', () => {
 
     it('fails to create a quote', async () => {
       // Arrange
+      const throwError = new Error('Create Quote Test Error')
       const handleException = jest.fn()
       BulkQuotesModel.mockImplementationOnce(() => ({
-        handleBulkQuoteRequest: async () => {
-          throw new Error('Create Quote Test Error')
-        },
+        handleBulkQuoteRequest: jest.fn(async () => {
+          throw throwError
+        }),
         handleException
       }))
       const code = jest.fn()
@@ -106,6 +107,7 @@ describe('/bulkQuotes', () => {
 
       // Assert
       expect(BulkQuotesModel).toHaveBeenCalledTimes(1)
+      expect(BulkQuotesModel.mock.results[0].value.handleBulkQuoteRequest.mock.results[0].value).rejects.toThrow(throwError)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.ACCEPTED.CODE)
     })
   })

--- a/test/unit/handlers/bulkQuotes/{id}.test.js
+++ b/test/unit/handlers/bulkQuotes/{id}.test.js
@@ -69,12 +69,13 @@ describe('/bulkQuotes/{id}', () => {
 
     it('handles an error with the model', async () => {
       // Arrange
+      const throwError = new Error('Create Quote Test Error')
       const handleException = jest.fn()
       BulkQuotesModel.mockImplementationOnce(() => {
         return {
-          handleBulkQuoteGet: async () => {
-            throw new Error('Test error')
-          },
+          handleBulkQuoteGet: jest.fn(async () => {
+            throw throwError
+          }),
           handleException
         }
       })
@@ -90,6 +91,7 @@ describe('/bulkQuotes/{id}', () => {
 
       // Assert
       expect(BulkQuotesModel).toHaveBeenCalledTimes(1)
+      expect(BulkQuotesModel.mock.results[0].value.handleBulkQuoteGet.mock.results[0].value).rejects.toThrow(throwError)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.ACCEPTED.CODE)
     })
   })
@@ -118,12 +120,13 @@ describe('/bulkQuotes/{id}', () => {
 
     it('handles an error with the model', async () => {
       // Arrange
+      const throwError = new Error('Create Quote Test Error')
       const handleException = jest.fn()
       BulkQuotesModel.mockImplementationOnce(() => {
         return {
-          handleBulkQuoteUpdate: async () => {
-            throw new Error('Test error')
-          },
+          handleBulkQuoteUpdate: jest.fn(async () => {
+            throw throwError
+          }),
           handleException
         }
       })
@@ -139,6 +142,7 @@ describe('/bulkQuotes/{id}', () => {
 
       // Assert
       expect(BulkQuotesModel).toHaveBeenCalledTimes(1)
+      expect(BulkQuotesModel.mock.results[0].value.handleBulkQuoteUpdate.mock.results[0].value).rejects.toThrow(throwError)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.OK.CODE)
     })
   })

--- a/test/unit/handlers/bulkQuotes/{id}.test.js
+++ b/test/unit/handlers/bulkQuotes/{id}.test.js
@@ -72,7 +72,7 @@ describe('/bulkQuotes/{id}', () => {
       const handleException = jest.fn()
       BulkQuotesModel.mockImplementationOnce(() => {
         return {
-          handleBulkQuoteGet: () => {
+          handleBulkQuoteGet: async () => {
             throw new Error('Test error')
           },
           handleException
@@ -90,7 +90,6 @@ describe('/bulkQuotes/{id}', () => {
 
       // Assert
       expect(BulkQuotesModel).toHaveBeenCalledTimes(1)
-      expect(handleException).toHaveBeenCalledTimes(1)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.ACCEPTED.CODE)
     })
   })
@@ -122,7 +121,7 @@ describe('/bulkQuotes/{id}', () => {
       const handleException = jest.fn()
       BulkQuotesModel.mockImplementationOnce(() => {
         return {
-          handleBulkQuoteUpdate: () => {
+          handleBulkQuoteUpdate: async () => {
             throw new Error('Test error')
           },
           handleException
@@ -140,7 +139,6 @@ describe('/bulkQuotes/{id}', () => {
 
       // Assert
       expect(BulkQuotesModel).toHaveBeenCalledTimes(1)
-      expect(handleException).toHaveBeenCalledTimes(1)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.OK.CODE)
     })
   })

--- a/test/unit/handlers/bulkQuotes/{id}/error.test.js
+++ b/test/unit/handlers/bulkQuotes/{id}/error.test.js
@@ -88,7 +88,7 @@ describe('/bulkQuotes/{id}/error', () => {
       const handleException = jest.fn()
       BulkQuotesModel.mockImplementationOnce(() => {
         return {
-          handleBulkQuoteError: () => {
+          handleBulkQuoteError: async () => {
             throw new Error('Test error')
           },
           handleException
@@ -106,7 +106,6 @@ describe('/bulkQuotes/{id}/error', () => {
 
       // Assert
       expect(BulkQuotesModel).toHaveBeenCalledTimes(1)
-      expect(handleException).toHaveBeenCalledTimes(1)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.OK.CODE)
     })
   })

--- a/test/unit/handlers/bulkQuotes/{id}/error.test.js
+++ b/test/unit/handlers/bulkQuotes/{id}/error.test.js
@@ -76,6 +76,7 @@ describe('/bulkQuotes/{id}/error', () => {
 
     it('handles an error with the model', async () => {
       // Arrange
+      const throwError = new Error('Create Quote Test Error')
       const request = {
         ...baseMockRequest,
         payload: {
@@ -88,9 +89,9 @@ describe('/bulkQuotes/{id}/error', () => {
       const handleException = jest.fn()
       BulkQuotesModel.mockImplementationOnce(() => {
         return {
-          handleBulkQuoteError: async () => {
-            throw new Error('Test error')
-          },
+          handleBulkQuoteError: jest.fn(async () => {
+            throw throwError
+          }),
           handleException
         }
       })
@@ -106,6 +107,7 @@ describe('/bulkQuotes/{id}/error', () => {
 
       // Assert
       expect(BulkQuotesModel).toHaveBeenCalledTimes(1)
+      expect(BulkQuotesModel.mock.results[0].value.handleBulkQuoteError.mock.results[0].value).rejects.toThrow(throwError)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.OK.CODE)
     })
   })

--- a/test/unit/handlers/quotes.test.js
+++ b/test/unit/handlers/quotes.test.js
@@ -75,11 +75,12 @@ describe('/quotes', () => {
 
     it('fails to create a quote', async () => {
       // Arrange
+      const throwError = new Error('Create Quote Test Error')
       const handleException = jest.fn(() => ({ code: Enum.Http.ReturnCodes.ACCEPTED.CODE }))
       QuotesModel.mockImplementationOnce(() => ({
-        handleQuoteRequest: async () => {
-          throw new Error('Create Quote Test Error')
-        },
+        handleQuoteRequest: jest.fn(async () => {
+          throw throwError
+        }),
         handleException
       }))
       const code = jest.fn()
@@ -104,6 +105,7 @@ describe('/quotes', () => {
 
       // Assert
       expect(QuotesModel).toHaveBeenCalledTimes(1)
+      expect(QuotesModel.mock.results[0].value.handleQuoteRequest.mock.results[0].value).rejects.toThrow(throwError)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.ACCEPTED.CODE)
     })
   })

--- a/test/unit/handlers/quotes.test.js
+++ b/test/unit/handlers/quotes.test.js
@@ -77,7 +77,7 @@ describe('/quotes', () => {
       // Arrange
       const handleException = jest.fn(() => ({ code: Enum.Http.ReturnCodes.ACCEPTED.CODE }))
       QuotesModel.mockImplementationOnce(() => ({
-        handleQuoteRequest: () => {
+        handleQuoteRequest: async () => {
           throw new Error('Create Quote Test Error')
         },
         handleException
@@ -103,8 +103,8 @@ describe('/quotes', () => {
       await QuotesHandler.post(mockContext, mockRequest, handler)
 
       // Assert
+      expect(QuotesModel).toHaveBeenCalledTimes(1)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.ACCEPTED.CODE)
-      expect(handleException).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/test/unit/handlers/quotes/{id}.test.js
+++ b/test/unit/handlers/quotes/{id}.test.js
@@ -66,12 +66,13 @@ describe('/quotes/{id}', () => {
 
     it('handles an error with the model', async () => {
       // Arrange
+      const throwError = new Error('Create Quote Test Error')
       const handleException = jest.fn(() => ({ code: Enum.Http.ReturnCodes.ACCEPTED.CODE }))
       QuotesModel.mockImplementationOnce(() => {
         return {
-          handleQuoteGet: async () => {
-            throw new Error('Test error')
-          },
+          handleQuoteGet: jest.fn(async () => {
+            throw throwError
+          }),
           handleException
         }
       })
@@ -86,6 +87,8 @@ describe('/quotes/{id}', () => {
       await QuotesHandler.get(mockContext, { ...baseMockRequest }, handler)
 
       // Assert
+      expect(QuotesModel).toHaveBeenCalledTimes(1)
+      expect(QuotesModel.mock.results[0].value.handleQuoteGet.mock.results[0].value).rejects.toThrow(throwError)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.ACCEPTED.CODE)
     })
   })
@@ -114,12 +117,13 @@ describe('/quotes/{id}', () => {
 
     it('handles an error with the model', async () => {
       // Arrange
+      const throwError = new Error('Create Quote Test Error')
       const handleException = jest.fn(() => ({ code: Enum.Http.ReturnCodes.ACCEPTED.CODE }))
       QuotesModel.mockImplementationOnce(() => {
         return {
-          handleQuoteUpdate: async () => {
-            throw new Error('Test error')
-          },
+          handleQuoteUpdate: jest.fn(async () => {
+            throw throwError
+          }),
           handleException
         }
       })
@@ -135,6 +139,7 @@ describe('/quotes/{id}', () => {
 
       // Assert
       expect(QuotesModel).toHaveBeenCalledTimes(1)
+      expect(QuotesModel.mock.results[0].value.handleQuoteUpdate.mock.results[0].value).rejects.toThrow(throwError)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.OK.CODE)
     })
   })

--- a/test/unit/handlers/quotes/{id}.test.js
+++ b/test/unit/handlers/quotes/{id}.test.js
@@ -69,7 +69,7 @@ describe('/quotes/{id}', () => {
       const handleException = jest.fn(() => ({ code: Enum.Http.ReturnCodes.ACCEPTED.CODE }))
       QuotesModel.mockImplementationOnce(() => {
         return {
-          handleQuoteGet: () => {
+          handleQuoteGet: async () => {
             throw new Error('Test error')
           },
           handleException
@@ -86,8 +86,6 @@ describe('/quotes/{id}', () => {
       await QuotesHandler.get(mockContext, { ...baseMockRequest }, handler)
 
       // Assert
-      expect(QuotesModel).toHaveBeenCalledTimes(1)
-      expect(handleException).toHaveBeenCalledTimes(1)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.ACCEPTED.CODE)
     })
   })
@@ -119,7 +117,7 @@ describe('/quotes/{id}', () => {
       const handleException = jest.fn(() => ({ code: Enum.Http.ReturnCodes.ACCEPTED.CODE }))
       QuotesModel.mockImplementationOnce(() => {
         return {
-          handleQuoteUpdate: () => {
+          handleQuoteUpdate: async () => {
             throw new Error('Test error')
           },
           handleException
@@ -137,7 +135,6 @@ describe('/quotes/{id}', () => {
 
       // Assert
       expect(QuotesModel).toHaveBeenCalledTimes(1)
-      expect(handleException).toHaveBeenCalledTimes(1)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.OK.CODE)
     })
   })

--- a/test/unit/handlers/quotes/{id}/error.test.js
+++ b/test/unit/handlers/quotes/{id}/error.test.js
@@ -76,6 +76,7 @@ describe('/quotes/{id}', () => {
 
     it('handles an error with the model', async () => {
       // Arrange
+      const throwError = new Error('Create Quote Test Error')
       const request = {
         ...baseMockRequest,
         payload: {
@@ -88,9 +89,9 @@ describe('/quotes/{id}', () => {
       const handleException = jest.fn(() => ({ code: Enum.Http.ReturnCodes.OK.CODE }))
       QuotesModel.mockImplementationOnce(() => {
         return {
-          handleQuoteError: async () => {
-            throw new Error('Test error')
-          },
+          handleQuoteError: jest.fn(async () => {
+            throw throwError
+          }),
           handleException
         }
       })
@@ -106,6 +107,7 @@ describe('/quotes/{id}', () => {
 
       // Assert
       expect(QuotesModel).toHaveBeenCalledTimes(1)
+      expect(QuotesModel.mock.results[0].value.handleQuoteError.mock.results[0].value).rejects.toThrow(throwError)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.OK.CODE)
     })
   })

--- a/test/unit/handlers/quotes/{id}/error.test.js
+++ b/test/unit/handlers/quotes/{id}/error.test.js
@@ -88,7 +88,7 @@ describe('/quotes/{id}', () => {
       const handleException = jest.fn(() => ({ code: Enum.Http.ReturnCodes.OK.CODE }))
       QuotesModel.mockImplementationOnce(() => {
         return {
-          handleQuoteError: () => {
+          handleQuoteError: async () => {
             throw new Error('Test error')
           },
           handleException
@@ -106,7 +106,6 @@ describe('/quotes/{id}', () => {
 
       // Assert
       expect(QuotesModel).toHaveBeenCalledTimes(1)
-      expect(handleException).toHaveBeenCalledTimes(1)
       expect(code).toHaveBeenCalledWith(Enum.Http.ReturnCodes.OK.CODE)
     })
   })


### PR DESCRIPTION
- added catch to fire-and-forget promises that are not "handled", otherwise the nodejs process would just exit on the unhandled promise, causing the k8s pods to restart during GP tests
- updated unit tests to correctly reject promises instead of just throwing an error (i.e. made mocked functions async), also check for rejections, and fix code-coverage issues
- updated dependencies
- fixed audit-resolve issues