### PR TITLE
fix(mojaloop/#3564): move get queries outside of transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "good-squeeze": "5.1.0",
         "joi": "17.11.0",
         "json-rules-engine": "5.0.2",
-        "knex": "2.5.1",
+        "knex": "3.0.1",
         "memory-cache": "0.2.0",
         "minimist": "1.2.8",
         "mysql": "2.18.1",
@@ -6862,19 +6862,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -9751,9 +9738,9 @@
       }
     },
     "node_modules/knex": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-2.5.1.tgz",
-      "integrity": "sha512-z78DgGKUr4SE/6cm7ku+jHvFT0X97aERh/f0MUKAKgFnwCYBEW4TFBqtHWFYiJFid7fMrtpZ/gxJthvz5mEByA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-3.0.1.tgz",
+      "integrity": "sha512-ruASxC6xPyDklRdrcDy6a9iqK+R9cGK214aiQa+D9gX2ZnHZKv6o6JC9ZfgxILxVAul4bZ13c3tgOAHSuQ7/9g==",
       "dependencies": {
         "colorette": "2.0.19",
         "commander": "^10.0.0",
@@ -9774,7 +9761,7 @@
         "knex": "bin/cli.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       },
       "peerDependenciesMeta": {
         "better-sqlite3": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quoting-service",
-  "version": "15.2.2",
+  "version": "15.2.3-snapshot.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quoting-service",
-      "version": "15.2.2",
+      "version": "15.2.3-snapshot.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/good": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "quoting-service",
   "description": "Quoting Service hosted by a scheme",
   "license": "Apache-2.0",
-  "version": "15.2.2",
+  "version": "15.2.3-snapshot.0",
   "author": "ModusBox",
   "contributors": [
     "Georgi Georgiev <georgi.georgiev@modusbox.com>",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "good-squeeze": "5.1.0",
     "joi": "17.11.0",
     "json-rules-engine": "5.0.2",
-    "knex": "2.5.1",
+    "knex": "3.0.1",
     "memory-cache": "0.2.0",
     "minimist": "1.2.8",
     "mysql": "2.18.1",

--- a/src/data/database.js
+++ b/src/data/database.js
@@ -463,9 +463,9 @@ class Database {
      *
      * @returns {promise}
      */
-  async createPayerQuoteParty (txn, quoteId, party, amount, currency) {
+  async createPayerQuoteParty (txn, quoteId, party, amount, currency, enumVals) {
     // note amount is negative for payee and positive for payer
-    return this.createQuoteParty(txn, quoteId, LOCAL_ENUM.PAYER, LOCAL_ENUM.PAYER_DFSP, LOCAL_ENUM.PRINCIPLE_VALUE, party, amount, currency)
+    return this.createQuoteParty(txn, quoteId, LOCAL_ENUM.PAYER, party, amount, currency, enumVals)
   }
 
   /**
@@ -473,9 +473,9 @@ class Database {
      *
      * @returns {promise}
      */
-  async createPayeeQuoteParty (txn, quoteId, party, amount, currency) {
+  async createPayeeQuoteParty (txn, quoteId, party, amount, currency, enumVals) {
     // note amount is negative for payee and positive for payer
-    return this.createQuoteParty(txn, quoteId, LOCAL_ENUM.PAYEE, LOCAL_ENUM.PAYEE_DFSP, LOCAL_ENUM.PRINCIPLE_VALUE, party, -amount, currency)
+    return this.createQuoteParty(txn, quoteId, LOCAL_ENUM.PAYEE, party, -amount, currency, enumVals)
   }
 
   /**
@@ -483,18 +483,9 @@ class Database {
      *
      * @returns {integer} - id of created quoteParty
      */
-  async createQuoteParty (txn, quoteId, partyType, participantType, ledgerEntryType, party, amount, currency) {
+  async createQuoteParty (txn, quoteId, partyType, party, amount, currency, enumVals) {
     try {
       const refs = {}
-
-      // get various enum ids (async, as parallel as possible)
-      const enumVals = await Promise.all([
-        this.getPartyType(partyType),
-        this.getPartyIdentifierType(party.partyIdInfo.partyIdType),
-        this.getParticipantByName(party.partyIdInfo.fspId),
-        this.getTransferParticipantRoleType(participantType),
-        this.getLedgerEntryType(ledgerEntryType)
-      ])
 
       refs.partyTypeId = enumVals[0]
       refs.partyIdentifierTypeId = enumVals[1]

--- a/src/model/quotes.js
+++ b/src/model/quotes.js
@@ -257,9 +257,6 @@ class QuotesModel {
 
         // todo: validation
 
-        // if we get here we need to create a duplicate check row
-        const hash = calculateRequestHash(quoteRequest)
-
         // get the initiator type
         refs.transactionInitiatorTypeId = await this.db.getInitiatorType(quoteRequest.transactionType.initiatorType)
 
@@ -293,6 +290,9 @@ class QuotesModel {
           this.db.getTransferParticipantRoleType(LOCAL_ENUM.PAYEE_DFSP),
           this.db.getLedgerEntryType(LOCAL_ENUM.PRINCIPLE_VALUE)
         ])
+
+        // if we get here we need to create a duplicate check row
+        const hash = calculateRequestHash(quoteRequest)
 
         // do everything in a db txn so we can rollback multiple operations if something goes wrong
         txn = await this.db.newTransaction()

--- a/test/unit/data/database.test.js
+++ b/test/unit/data/database.test.js
@@ -1079,21 +1079,27 @@ describe('/database', () => {
         const party = {}
         const amount = 100
         const currency = 'AUD'
+        const enumVals = [
+          'testPartyTypeId',
+          'testPartyIdentifierTypeId',
+          'testParticipantId',
+          'testTransferParticipantRoleTypeId',
+          'testLedgerEntryTypeId'
+        ]
         database.createQuoteParty = jest.fn()
 
         // Act
-        database.createPayerQuoteParty(txn, quoteId, party, amount, currency)
+        database.createPayerQuoteParty(txn, quoteId, party, amount, currency, enumVals)
 
         // Assert
         expect(database.createQuoteParty).toHaveBeenCalledWith(
           txn,
           quoteId,
           LibEnum.PAYER,
-          LibEnum.PAYER_DFSP,
-          LibEnum.PRINCIPLE_VALUE,
           party,
           100,
-          'AUD'
+          'AUD',
+          enumVals
         )
       })
     })
@@ -1106,21 +1112,27 @@ describe('/database', () => {
         const party = {}
         const amount = 100
         const currency = 'AUD'
+        const enumVals = [
+          'testPartyTypeId',
+          'testPartyIdentifierTypeId',
+          'testParticipantId',
+          'testTransferParticipantRoleTypeId',
+          'testLedgerEntryTypeId'
+        ]
         database.createQuoteParty = jest.fn()
 
         // Act
-        database.createPayeeQuoteParty(txn, quoteId, party, amount, currency)
+        database.createPayeeQuoteParty(txn, quoteId, party, amount, currency, enumVals)
 
         // Assert
         expect(database.createQuoteParty).toHaveBeenCalledWith(
           txn,
           quoteId,
           LibEnum.PAYEE,
-          LibEnum.PAYEE_DFSP,
-          LibEnum.PRINCIPLE_VALUE,
           party,
           -100,
-          'AUD'
+          'AUD',
+          enumVals
         )
       })
     })
@@ -1128,13 +1140,18 @@ describe('/database', () => {
     describe('createQuoteParty', () => {
       const quoteId = 'ddaa67b3-5bf8-45c1-bfcf-1e8781177c37'
       const partyType = LibEnum.PAYEE
-      const participantType = LibEnum.PAYEE_DFSP
-      const ledgerEntryType = LibEnum.PRINCIPLE_VALUE
       const amount = 100
       const currency = 'AUD'
       const quoteParty = {
         quotePartyId: 'ddaa67b3-5bf8-45c1-bfcf-1e8781177c37'
       }
+      const enumVals = [
+        'testPartyTypeId',
+        'testPartyIdentifierTypeId',
+        'testParticipantId',
+        'testTransferParticipantRoleTypeId',
+        'testLedgerEntryTypeId'
+      ]
       beforeEach(() => {
         database.getPartyType = jest.fn().mockResolvedValueOnce('testPartyTypeId')
         database.getPartyIdentifierType = jest.fn().mockResolvedValueOnce('testPartyIdentifierTypeId')
@@ -1188,7 +1205,7 @@ describe('/database', () => {
         }
 
         // Act
-        const result = await database.createQuoteParty(txn, quoteId, partyType, participantType, ledgerEntryType, party, amount, currency)
+        const result = await database.createQuoteParty(txn, quoteId, partyType, party, amount, currency, enumVals)
 
         // Assert
         expect(result).toBe('12345')
@@ -1234,7 +1251,7 @@ describe('/database', () => {
         }
 
         // Act
-        const result = await database.createQuoteParty(txn, quoteId, partyType, participantType, ledgerEntryType, party, amount, currency)
+        const result = await database.createQuoteParty(txn, quoteId, partyType, party, amount, currency, enumVals)
 
         // Assert
         expect(result).toBe('12345')
@@ -1292,7 +1309,7 @@ describe('/database', () => {
         }
 
         // Act
-        const result = await database.createQuoteParty(txn, quoteId, partyType, participantType, ledgerEntryType, party, amount, currency)
+        const result = await database.createQuoteParty(txn, quoteId, partyType, party, amount, currency, enumVals)
 
         // Assert
         expect(result).toBe('12345')
@@ -1317,7 +1334,7 @@ describe('/database', () => {
         mockKnex.mockImplementationOnce(() => { throw new Error('Test Error') })
 
         // Act
-        const action = async () => database.createQuoteParty(txn, quoteId, partyType, participantType, ledgerEntryType, party, amount, currency)
+        const action = async () => database.createQuoteParty(txn, quoteId, partyType, party, amount, currency, enumVals)
 
         // Assert
         await expect(action()).rejects.toThrowError('Test Error')

--- a/test/unit/model/quotes.test.js
+++ b/test/unit/model/quotes.test.js
@@ -333,6 +333,12 @@ describe('QuotesModel', () => {
     quotesModel.db.createGeoCode.mockImplementation(() => mockData.geoCode)
     quotesModel.db.createQuoteExtensions.mockImplementation(() => mockData.quoteRequest.extensionList.extension)
 
+    quotesModel.db.getPartyType.mockImplementation(() => 'testPartyTypeId')
+    quotesModel.db.getPartyIdentifierType.mockImplementation(() => 'testPartyIdentifierTypeId')
+    quotesModel.db.getTransferParticipantRoleType.mockImplementation(() => 'testTransferParticipantRoleType')
+    quotesModel.db.getParticipantByName.mockImplementation(() => 'testParticipantId')
+    quotesModel.db.getLedgerEntryType.mockImplementation(() => 'testLedgerEntryTypeId')
+
     // make all methods of the quotesModel instance be a mock. This helps us re-mock in every
     // method's test suite.
     const propertyNames = Object.getOwnPropertyNames(QuotesModel.prototype)
@@ -1135,10 +1141,22 @@ describe('QuotesModel', () => {
             }]
             const mockCreatePayerQuotePartyArgs = [mockTransaction, mockData.quoteRequest.quoteId,
               mockData.quoteRequest.payer, mockData.quoteRequest.amount.amount,
-              mockData.quoteRequest.amount.currency]
+              mockData.quoteRequest.amount.currency, [
+                'testPartyTypeId',
+                'testPartyIdentifierTypeId',
+                'testParticipantId',
+                'testTransferParticipantRoleType',
+                'testLedgerEntryTypeId'
+              ]]
             const mockCreatePayeeQuotePartyArgs = [mockTransaction, mockData.quoteRequest.quoteId,
               mockData.quoteRequest.payee, mockData.quoteRequest.amount.amount,
-              mockData.quoteRequest.amount.currency]
+              mockData.quoteRequest.amount.currency, [
+                'testPartyTypeId',
+                'testPartyIdentifierTypeId',
+                'testParticipantId',
+                'testTransferParticipantRoleType',
+                'testLedgerEntryTypeId'
+              ]]
             const mockCreateQuoteExtensionsArgs = [mockTransaction,
               mockData.quoteRequest.extensionList.extension,
               mockData.quoteRequest.quoteId,
@@ -1555,7 +1573,7 @@ describe('QuotesModel', () => {
       expect(mockChildSpan.finish).not.toBeCalled()
       expect(refs).toEqual(expected)
     })
-    it('should throw partyNotFound error when getQuoteParty coldn\'t find a record in switch mode', async () => {
+    it('should throw partyNotFound error when getQuoteParty couldn\'t find a record in switch mode', async () => {
       expect.assertions(4)
 
       mockConfig.simpleRoutingMode = false
@@ -1571,8 +1589,8 @@ describe('QuotesModel', () => {
       try {
         await quotesModel.handleQuoteUpdate(mockData.headers, mockData.quoteId, mockData.quoteUpdate, mockSpan)
       } catch (err) {
-        expect(quotesModel.db.newTransaction.mock.calls.length).toBe(1)
-        expect(mockTransaction.rollback.mock.calls.length).toBe(1)
+        expect(quotesModel.db.newTransaction.mock.calls.length).toBe(0)
+        expect(mockTransaction.rollback.mock.calls.length).toBe(0)
         expect(err instanceof ErrorHandler.Factory.FSPIOPError).toBeTruthy()
         expect(err.apiErrorCode.code).toBe(ErrorHandler.Enums.FSPIOPErrorCodes.PARTY_NOT_FOUND.code)
       }


### PR DESCRIPTION
fix(mojaloop/#3564): move get queries outside of transaction - https://app.zenhub.com/workspaces/mojaloop-project-59edee71d1407922110cf083/issues/gh/mojaloop/project/3564

- Move get queries before transaction is opened.