### PR TITLE
feat: add cache bypassing feature

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -32,7 +32,12 @@ ignore:
   - vulnerability: GHSA-qffp-2rhf-9h96
   - vulnerability: GHSA-9ppj-qmqm-q256 #  tar 7.5.7
   - vulnerability: CVE-2026-2673 # libcrypto3, libssl3 — Alpine OpenSSL system package
-
+  - vulnerability: GHSA-44fc-8fm5-q62h
+  - vulnerability: GHSA-hf2r-9gf9-rwch
+  - vulnerability: GHSA-c2c7-rcm5-vvqj
+  - vulnerability: GHSA-f886-m6hf-6m8v
+  - vulnerability: GHSA-3v7f-55p6-f55p
+  - vulnerability: GHSA-48c2-rrv3-qjmp
 # Set output format defaults
 output:
   - "table"

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -4,6 +4,10 @@
   // Only use one of ["low": true, "moderate": true, "high": true, "critical": true]
   "moderate": true,
   "allowlist": [
-    "GHSA-wf6x-7x77-mvgw"
+    "GHSA-wf6x-7x77-mvgw",
+    "GHSA-44fc-8fm5-q62h",
+    "GHSA-48c2-rrv3-qjmp",
+    "GHSA-f886-m6hf-6m8v",
+    "GHSA-hf2r-9gf9-rwch"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -726,9 +726,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1488,9 +1488,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2776,9 +2776,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.10",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.10.tgz",
-      "integrity": "sha512-XCBR/9WHJ0cpezuunHMZjuFMl4KqUo7eiFwzrQrvm7lTXt0EBd3No8UY+9OyzXpDfreGEMMtxmaLZ+ksVw378g==",
+      "version": "1.34.11",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.11.tgz",
+      "integrity": "sha512-V09ayfnb5GyysmvARbt+voFZAjGcf7hSYxOYxSkCc4fbH/DTfq5YWoec8cflvmHHqyIFbqvmGKmYFzqhr9zxDg==",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "8.11.2",
@@ -3176,9 +3176,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4132,9 +4132,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5789,9 +5789,9 @@
       }
     },
     "node_modules/dotgitignore/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6527,9 +6527,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6644,9 +6644,9 @@
       }
     },
     "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6719,9 +6719,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6837,9 +6837,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8106,9 +8106,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8197,9 +8197,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9633,9 +9633,9 @@
       }
     },
     "node_modules/istanbul-lib-processinfo/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12168,9 +12168,9 @@
       }
     },
     "node_modules/nyc/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12439,9 +12439,9 @@
       }
     },
     "node_modules/oas-linter/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -12467,9 +12467,9 @@
       }
     },
     "node_modules/oas-resolver/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -12504,9 +12504,9 @@
       }
     },
     "node_modules/oas-validator/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -13331,9 +13331,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -14340,9 +14340,9 @@
       }
     },
     "node_modules/replace/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15083,9 +15083,9 @@
       }
     },
     "node_modules/shins/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -15339,9 +15339,9 @@
       }
     },
     "node_modules/spawn-wrap/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15796,9 +15796,9 @@
       }
     },
     "node_modules/standard/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16367,9 +16367,9 @@
       }
     },
     "node_modules/swagger2openapi/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -16487,9 +16487,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16600,9 +16600,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17615,9 +17615,9 @@
       "license": "ISC"
     },
     "node_modules/widdershins/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"

--- a/src/data/cachedDatabase.js
+++ b/src/data/cachedDatabase.js
@@ -96,6 +96,14 @@ class CachedDatabase extends Database {
     return this.getCacheValue('getParticipantByName', [participantName, participantType])
   }
 
+  async getParticipantNoCache (...args) {
+    return super.getParticipant(...args)
+  }
+
+  async getParticipantByNameNoCache (...args) {
+    return super.getParticipantByName(...args)
+  }
+
   async getTransferParticipantRoleType (name) {
     return this.getCacheValue('getTransferParticipantRoleType', [name])
   }

--- a/src/data/database.js
+++ b/src/data/database.js
@@ -407,6 +407,26 @@ class Database {
   }
 
   /**
+   * Gets the id of the specified participant, bypassing any cache layer.
+   * On the base Database class this is identical to getParticipant.
+   *
+   * @returns {promise} - id of the participant
+   */
+  async getParticipantNoCache (...args) {
+    return this.getParticipant(...args)
+  }
+
+  /**
+   * Gets the id of the specified participant by name, bypassing any cache layer.
+   * On the base Database class this is identical to getParticipantByName.
+   *
+   * @returns {promise} - id of the participant
+   */
+  async getParticipantByNameNoCache (...args) {
+    return this.getParticipantByName(...args)
+  }
+
+  /**
      * Gets the id of the specified transfer participant role type
      *
      * @returns {promise} - id of the transfer participant role type

--- a/src/model/BaseQuotesModel.js
+++ b/src/model/BaseQuotesModel.js
@@ -145,6 +145,65 @@ class BaseQuotesModel {
     return { payer, payee }
   }
 
+  /**
+   * Parses a W3C baggage header value (comma-separated key=value pairs).
+   *
+   * @param {string} baggage - raw baggage header value
+   * @returns {Object} - key/value map
+   */
+  static _parseBaggageHeader (baggage) {
+    if (!baggage) return {}
+    return Object.fromEntries(
+      baggage.split(',')
+        .map(entry => entry.trim().split('='))
+        .filter(parts => parts.length >= 2)
+        .map(([key, ...rest]) => [key.trim(), rest.join('=').trim()])
+    )
+  }
+
+  /**
+   * Returns true when the baggage header carries `test-instruction=skip-participant-cache`.
+   *
+   * @param {Object} headers - incoming HTTP headers
+   * @returns {boolean}
+   */
+  static _shouldSkipParticipantCache (headers) {
+    const baggage = headers?.baggage
+    if (!baggage) return false
+    const parsed = BaseQuotesModel._parseBaggageHeader(baggage)
+    return parsed['test-instruction'] === 'skip-participant-cache'
+  }
+
+  /**
+   * Retrieves a participant, bypassing the cache when the baggage header instructs it.
+   *
+   * @param {Object} headers - incoming HTTP headers
+   * @param  {...any} args - forwarded to db.getParticipant / db.getParticipantNoCache
+   * @returns {Promise<number>} participantId
+   */
+  async _getParticipant (headers, ...args) {
+    if (BaseQuotesModel._shouldSkipParticipantCache(headers)) {
+      this.log.debug('skip-participant-cache: bypassing cache for getParticipant')
+      return this.db.getParticipantNoCache(...args)
+    }
+    return this.db.getParticipant(...args)
+  }
+
+  /**
+   * Retrieves a participant by name, bypassing the cache when the baggage header instructs it.
+   *
+   * @param {Object} headers - incoming HTTP headers
+   * @param  {...any} args - forwarded to db.getParticipantByName / db.getParticipantByNameNoCache
+   * @returns {Promise<number>} participantId
+   */
+  async _getParticipantByName (headers, ...args) {
+    if (BaseQuotesModel._shouldSkipParticipantCache(headers)) {
+      this.log.debug('skip-participant-cache: bypassing cache for getParticipantByName')
+      return this.db.getParticipantByNameNoCache(...args)
+    }
+    return this.db.getParticipantByName(...args)
+  }
+
   makeErrorCallbackHeaders ({ modifyHeaders, headers, fspiopSource, fspiopUri, resource = RESOURCES.quotes }) {
     const { envConfig } = this
     let fromSwitchHeaders

--- a/src/model/BaseQuotesModel.js
+++ b/src/model/BaseQuotesModel.js
@@ -146,17 +146,22 @@ class BaseQuotesModel {
   }
 
   /**
-   * Parses a W3C baggage header value (comma-separated key=value pairs).
+   * Parses a W3C baggage header value as comma-separated list-members of `key=value`
+   * and ignores any per-entry properties (everything after the first `;` in a member).
    *
    * @param {string} baggage - raw baggage header value
    * @returns {Object} - key/value map
    */
   static _parseBaggageHeader (baggage) {
-    if (!baggage) return {}
+    if (!baggage || typeof baggage !== 'string') return {}
     return Object.fromEntries(
       baggage.split(',')
-        .map(entry => entry.trim().split('='))
-        .filter(parts => parts.length >= 2)
+        .map(entry => entry.trim())
+        .filter(entry => entry.length > 0)
+        // Discard per-entry properties, which follow the first ';' per W3C baggage
+        .map(entry => entry.split(';', 1)[0])
+        .map(member => member.split('='))
+        .filter(parts => parts.length >= 2 && parts[0].trim().length > 0)
         .map(([key, ...rest]) => [key.trim(), rest.join('=').trim()])
     )
   }

--- a/src/model/BaseQuotesModel.js
+++ b/src/model/BaseQuotesModel.js
@@ -146,15 +146,44 @@ class BaseQuotesModel {
   }
 
   /**
-   * Parses a W3C baggage header value (comma-separated key=value pairs).
+   * Retrieves a header value with case-insensitive key lookup and array coercion.
+   * Handles different HTTP stack behaviors where headers may be lowercase/mixed-case
+   * or provided as arrays (when repeated in the request).
    *
-   * @param {string} baggage - raw baggage header value
+   * @param {Object} headers - incoming HTTP headers
+   * @param {string} headerName - header name to look up (e.g., 'baggage')
+   * @returns {string|undefined} - normalized header value or undefined
+   */
+  static _getNormalizedHeaderValue (headers, headerName) {
+    if (!headers || typeof headers !== 'object') return undefined
+
+    // Case-insensitive lookup
+    const key = Object.keys(headers).find(k => k.toLowerCase() === headerName.toLowerCase())
+    if (!key) return undefined
+
+    const value = headers[key]
+    // Coerce arrays to string by joining (HTTP allows repeated headers as arrays)
+    if (Array.isArray(value)) {
+      return value.join(',')
+    }
+    // Convert to string in case it's not already
+    return String(value || '')
+  }
+
+  /**
+   * Parses a W3C baggage header value (comma-separated key=value pairs).
+   * Handles string or array input.
+   *
+   * @param {string|string[]} baggage - raw baggage header value (string or array)
    * @returns {Object} - key/value map
    */
   static _parseBaggageHeader (baggage) {
     if (!baggage) return {}
+    // Coerce to string (handle array input from array header)
+    const baggageStr = Array.isArray(baggage) ? baggage.join(',') : String(baggage)
+    if (!baggageStr) return {}
     return Object.fromEntries(
-      baggage.split(',')
+      baggageStr.split(',')
         .map(entry => entry.trim().split('='))
         .filter(parts => parts.length >= 2)
         .map(([key, ...rest]) => [key.trim(), rest.join('=').trim()])
@@ -163,12 +192,13 @@ class BaseQuotesModel {
 
   /**
    * Returns true when the baggage header carries `test-instruction=skip-participant-cache`.
+   * Handles case-insensitive header lookup and array header values.
    *
    * @param {Object} headers - incoming HTTP headers
    * @returns {boolean}
    */
   static _shouldSkipParticipantCache (headers) {
-    const baggage = headers?.baggage
+    const baggage = BaseQuotesModel._getNormalizedHeaderValue(headers, 'baggage')
     if (!baggage) return false
     const parsed = BaseQuotesModel._parseBaggageHeader(baggage)
     return parsed['test-instruction'] === 'skip-participant-cache'

--- a/src/model/bulkQuotes.js
+++ b/src/model/bulkQuotes.js
@@ -51,14 +51,14 @@ class BulkQuotesModel extends BaseQuotesModel {
    *
    * @returns {promise} - promise will reject if request is not valid
    */
-  async validateBulkQuoteRequest (fspiopSource, fspiopDestination, bulkQuoteRequest) {
-    await this.db.getParticipant(fspiopSource, LOCAL_ENUM.PAYER_DFSP, bulkQuoteRequest.individualQuotes[0].amount.currency, Enum.Accounts.LedgerAccountType.POSITION)
+  async validateBulkQuoteRequest (fspiopSource, fspiopDestination, bulkQuoteRequest, headers = {}) {
+    await this._getParticipant(headers, fspiopSource, LOCAL_ENUM.PAYER_DFSP, bulkQuoteRequest.individualQuotes[0].amount.currency, Enum.Accounts.LedgerAccountType.POSITION)
 
     // Ensure the proxy client is connected
     if (this.proxyClient?.isConnected === false) await this.proxyClient.connect()
     // if the payee dfsp has a proxy cache entry, we do not validate the dfsp here
     if (!(await this.proxyClient?.lookupProxyByDfspId(fspiopDestination))) {
-      await this.db.getParticipant(fspiopDestination, LOCAL_ENUM.PAYEE_DFSP, bulkQuoteRequest.individualQuotes[0].amount.currency, Enum.Accounts.LedgerAccountType.POSITION)
+      await this._getParticipant(headers, fspiopDestination, LOCAL_ENUM.PAYEE_DFSP, bulkQuoteRequest.individualQuotes[0].amount.currency, Enum.Accounts.LedgerAccountType.POSITION)
     }
   }
 
@@ -78,7 +78,7 @@ class BulkQuotesModel extends BaseQuotesModel {
 
       // validate - this will throw if the request is invalid
       childSpan = span.getChild('qs_bulkquote_forwardBulkQuoteRequest')
-      await this.validateBulkQuoteRequest(fspiopSource, fspiopDestination, bulkQuoteRequest)
+      await this.validateBulkQuoteRequest(fspiopSource, fspiopDestination, bulkQuoteRequest, headers)
       // if we got here rules passed, so we can forward the quote on to the recipient dfsp
       this.envConfig.simpleAudit || await childSpan.audit({ headers, payload: bulkQuoteRequest }, EventSdk.AuditEventAction.start)
       await this.forwardBulkQuoteRequest(headers, bulkQuoteRequest.bulkQuoteId, bulkQuoteRequest, childSpan)

--- a/src/model/fxQuotes.js
+++ b/src/model/fxQuotes.js
@@ -47,7 +47,7 @@ class FxQuotesModel extends BaseQuotesModel {
    *
    * @returns {promise} - promise will reject if request is not valid
    */
-  async validateFxQuoteRequest (fspiopDestination, fxQuoteRequest) {
+  async validateFxQuoteRequest (fspiopDestination, fxQuoteRequest, headers = {}) {
     const histTimer = Metrics.getHistogram(
       'model_fxquote',
       'validateFxQuoteRequest - Metrics for fx quote model',
@@ -65,7 +65,7 @@ class FxQuotesModel extends BaseQuotesModel {
           await this.proxyClient?.addDfspIdToProxyMapping(fspiopDestination, selfHealFXPProxy)
         } else {
           await Promise.all(currencies.map((currency) => {
-            return this.db.getParticipant(fspiopDestination, LOCAL_ENUM.COUNTERPARTY_FSP, currency, Enum.Accounts.LedgerAccountType.POSITION)
+            return this._getParticipant(headers, fspiopDestination, LOCAL_ENUM.COUNTERPARTY_FSP, currency, Enum.Accounts.LedgerAccountType.POSITION)
           }))
         }
       }
@@ -181,7 +181,7 @@ class FxQuotesModel extends BaseQuotesModel {
       fspiopSource = headers[Enum.Http.Headers.FSPIOP.SOURCE]
       const fspiopDestination = headers[Enum.Http.Headers.FSPIOP.DESTINATION]
 
-      await this.validateFxQuoteRequest(fspiopDestination, fxQuoteRequest)
+      await this.validateFxQuoteRequest(fspiopDestination, fxQuoteRequest, headers)
 
       if (!this.envConfig.simpleRoutingMode) {
         // if we get here we need to create a duplicate check row

--- a/src/model/quotes.js
+++ b/src/model/quotes.js
@@ -58,7 +58,7 @@ class QuotesModel extends BaseQuotesModel {
    *
    * @returns {promise} - promise will reject if request is not valid
    */
-  async validateQuoteRequest (fspiopSource, fspiopDestination, quoteRequest) {
+  async validateQuoteRequest (fspiopSource, fspiopDestination, quoteRequest, headers = {}) {
     const histTimer = Metrics.getHistogram(
       'model_quote',
       'validateQuoteRequest - Metrics for quote model',
@@ -97,14 +97,14 @@ class QuotesModel extends BaseQuotesModel {
       ) {
         step = 'getParticipant-3'
         await Promise.all(quoteRequest.payer.supportedCurrencies.map(currency =>
-          this.db.getParticipant(fspiopSource, LOCAL_ENUM.PAYER_DFSP, currency, Enum.Accounts.LedgerAccountType.POSITION)
+          this._getParticipant(headers, fspiopSource, LOCAL_ENUM.PAYER_DFSP, currency, Enum.Accounts.LedgerAccountType.POSITION)
         ))
       } else {
         // If it is not passed in, then we validate payee against the `amount` currency.
         // if the payee dfsp has a proxy cache entry, we do not validate the dfsp here
         if (!(await this.proxyClient?.lookupProxyByDfspId(fspiopDestination))) {
           step = 'getParticipant-4'
-          await this.db.getParticipant(fspiopDestination, LOCAL_ENUM.PAYEE_DFSP, quoteRequest.amount.currency, Enum.Accounts.LedgerAccountType.POSITION)
+          await this._getParticipant(headers, fspiopDestination, LOCAL_ENUM.PAYEE_DFSP, quoteRequest.amount.currency, Enum.Accounts.LedgerAccountType.POSITION)
         }
       }
 
@@ -120,7 +120,7 @@ class QuotesModel extends BaseQuotesModel {
           !(await this.proxyClient?.lookupProxyByDfspId(quoteRequest.payer.partyIdInfo.fspId))
         ) {
           step = 'getParticipant-6'
-          await this.db.getParticipant(quoteRequest.payer.partyIdInfo.fspId, LOCAL_ENUM.PAYER_DFSP, quoteRequest.amount.currency, Enum.Accounts.LedgerAccountType.POSITION)
+          await this._getParticipant(headers, quoteRequest.payer.partyIdInfo.fspId, LOCAL_ENUM.PAYER_DFSP, quoteRequest.amount.currency, Enum.Accounts.LedgerAccountType.POSITION)
         }
         // Lets make sure the optional fspId exists in the payee's partyIdInfo before we validate it
         step = 'lookupProxyByDfspId-7'
@@ -131,7 +131,7 @@ class QuotesModel extends BaseQuotesModel {
           !(await this.proxyClient?.lookupProxyByDfspId(quoteRequest.payee.partyIdInfo.fspId))
         ) {
           step = 'getParticipant-8'
-          await this.db.getParticipant(quoteRequest.payee.partyIdInfo.fspId, LOCAL_ENUM.PAYEE_DFSP, quoteRequest.amount.currency, Enum.Accounts.LedgerAccountType.POSITION)
+          await this._getParticipant(headers, quoteRequest.payee.partyIdInfo.fspId, LOCAL_ENUM.PAYEE_DFSP, quoteRequest.amount.currency, Enum.Accounts.LedgerAccountType.POSITION)
         }
       }
       histTimer({ success: true, queryName: 'quote_validateQuoteRequest' })
@@ -161,7 +161,7 @@ class QuotesModel extends BaseQuotesModel {
     // skip fulfil validation if the source is a proxy
     if (!proxyIdSource) {
       const payeeCurrency = quoteUpdateRequest.payeeReceiveAmount?.currency || quoteUpdateRequest.transferAmount.currency
-      await this.db.getParticipant(fspiopSource, LOCAL_ENUM.PAYEE_DFSP, payeeCurrency, Enum.Accounts.LedgerAccountType.POSITION)
+      await this._getParticipant(headers, fspiopSource, LOCAL_ENUM.PAYEE_DFSP, payeeCurrency, Enum.Accounts.LedgerAccountType.POSITION)
     }
   }
 
@@ -191,7 +191,7 @@ class QuotesModel extends BaseQuotesModel {
     const handleQuoteRequestSpan = span.getChild('qs_quote_handleQuoteRequest')
     try {
       step = 'validateQuoteRequest-1'
-      await this.validateQuoteRequest(fspiopSource, fspiopDestination, quoteRequest)
+      await this.validateQuoteRequest(fspiopSource, fspiopDestination, quoteRequest, headers)
 
       step = 'fetchParticipantInfo-2'
       const { payer, payee } = await super.fetchParticipantsInfo(fspiopSource, fspiopDestination, cache)
@@ -231,12 +231,12 @@ class QuotesModel extends BaseQuotesModel {
           this.db.getAmountType(quoteRequest.amountType),
           this.db.getPartyType(LOCAL_ENUM.PAYER),
           this.db.getPartyIdentifierType(quoteRequest.payer.partyIdInfo.partyIdType),
-          payer.proxiedParticipant ? null : this.db.getParticipantByName(quoteRequest.payer.partyIdInfo.fspId),
+          payer.proxiedParticipant ? null : this._getParticipantByName(headers, quoteRequest.payer.partyIdInfo.fspId),
           this.db.getTransferParticipantRoleType(LOCAL_ENUM.PAYER_DFSP),
           this.db.getLedgerEntryType(LOCAL_ENUM.PRINCIPLE_VALUE),
           this.db.getPartyType(LOCAL_ENUM.PAYEE),
           this.db.getPartyIdentifierType(quoteRequest.payee.partyIdInfo.partyIdType),
-          payee.proxiedParticipant ? null : this.db.getParticipantByName(quoteRequest.payee.partyIdInfo.fspId),
+          payee.proxiedParticipant ? null : this._getParticipantByName(headers, quoteRequest.payee.partyIdInfo.fspId),
           this.db.getTransferParticipantRoleType(LOCAL_ENUM.PAYEE_DFSP),
           this.db.getLedgerEntryType(LOCAL_ENUM.PRINCIPLE_VALUE)
         ])

--- a/test/unit/model/BaseQuotesModel.test.js
+++ b/test/unit/model/BaseQuotesModel.test.js
@@ -58,4 +58,94 @@ describe('BaseQuotesModel Tests -->', () => {
     expect(errMessage).toBe('error initializing metrics in BaseQuotesModel: ')
     expect(meta.attributes?.['exception.stacktrace']).toBe(error.stack)
   })
+
+  describe('_parseBaggageHeader', () => {
+    test('should parse comma-separated key=value pairs', () => {
+      const baggage = 'foo=bar,test-instruction=skip-participant-cache,sample=123'
+
+      const result = BaseQuotesModel._parseBaggageHeader(baggage)
+
+      expect(result).toEqual({
+        foo: 'bar',
+        'test-instruction': 'skip-participant-cache',
+        sample: '123'
+      })
+    })
+
+    test('should tolerate spaces around entries', () => {
+      const baggage = ' foo = bar , test-instruction = skip-participant-cache '
+
+      const result = BaseQuotesModel._parseBaggageHeader(baggage)
+
+      expect(result).toEqual({
+        foo: 'bar',
+        'test-instruction': 'skip-participant-cache'
+      })
+    })
+  })
+
+  describe('_shouldSkipParticipantCache', () => {
+    test('should return true when baggage contains test-instruction=skip-participant-cache', () => {
+      const headers = {
+        baggage: 'foo=bar,test-instruction=skip-participant-cache,sample=123'
+      }
+
+      expect(BaseQuotesModel._shouldSkipParticipantCache(headers)).toBe(true)
+    })
+
+    test('should return false when baggage does not contain test instruction', () => {
+      const headers = { baggage: 'foo=bar,sample=123' }
+      expect(BaseQuotesModel._shouldSkipParticipantCache(headers)).toBe(false)
+    })
+  })
+
+  describe('participant cache bypass helpers', () => {
+    test('should use cached getParticipant when skip flag is absent', async () => {
+      db.getParticipant = jest.fn().mockResolvedValue('cached-participant-id')
+      db.getParticipantNoCache = jest.fn().mockResolvedValue('no-cache-participant-id')
+      const model = new BaseQuotesModel(deps)
+
+      const result = await model._getParticipant({ baggage: 'foo=bar' }, 'fsp1', 'PAYER_DFSP', 'USD')
+
+      expect(result).toBe('cached-participant-id')
+      expect(db.getParticipant).toBeCalledWith('fsp1', 'PAYER_DFSP', 'USD')
+      expect(db.getParticipantNoCache).not.toBeCalled()
+    })
+
+    test('should bypass cache for getParticipant when skip flag is present', async () => {
+      db.getParticipant = jest.fn().mockResolvedValue('cached-participant-id')
+      db.getParticipantNoCache = jest.fn().mockResolvedValue('no-cache-participant-id')
+      const model = new BaseQuotesModel(deps)
+
+      const result = await model._getParticipant({ baggage: 'foo=bar,test-instruction=skip-participant-cache' }, 'fsp1', 'PAYER_DFSP', 'USD')
+
+      expect(result).toBe('no-cache-participant-id')
+      expect(db.getParticipantNoCache).toBeCalledWith('fsp1', 'PAYER_DFSP', 'USD')
+      expect(db.getParticipant).not.toBeCalled()
+    })
+
+    test('should use cached getParticipantByName when skip flag is absent', async () => {
+      db.getParticipantByName = jest.fn().mockResolvedValue('cached-by-name-id')
+      db.getParticipantByNameNoCache = jest.fn().mockResolvedValue('no-cache-by-name-id')
+      const model = new BaseQuotesModel(deps)
+
+      const result = await model._getParticipantByName({ baggage: 'foo=bar' }, 'fsp1')
+
+      expect(result).toBe('cached-by-name-id')
+      expect(db.getParticipantByName).toBeCalledWith('fsp1')
+      expect(db.getParticipantByNameNoCache).not.toBeCalled()
+    })
+
+    test('should bypass cache for getParticipantByName when skip flag is present', async () => {
+      db.getParticipantByName = jest.fn().mockResolvedValue('cached-by-name-id')
+      db.getParticipantByNameNoCache = jest.fn().mockResolvedValue('no-cache-by-name-id')
+      const model = new BaseQuotesModel(deps)
+
+      const result = await model._getParticipantByName({ baggage: 'test-instruction=skip-participant-cache,foo=bar' }, 'fsp1')
+
+      expect(result).toBe('no-cache-by-name-id')
+      expect(db.getParticipantByNameNoCache).toBeCalledWith('fsp1')
+      expect(db.getParticipantByName).not.toBeCalled()
+    })
+  })
 })

--- a/test/unit/model/BaseQuotesModel.test.js
+++ b/test/unit/model/BaseQuotesModel.test.js
@@ -59,6 +59,61 @@ describe('BaseQuotesModel Tests -->', () => {
     expect(meta.attributes?.['exception.stacktrace']).toBe(error.stack)
   })
 
+  describe('_getNormalizedHeaderValue', () => {
+    test('should retrieve header with lowercase name', () => {
+      const headers = { baggage: 'test-instruction=skip-participant-cache' }
+
+      const result = BaseQuotesModel._getNormalizedHeaderValue(headers, 'baggage')
+
+      expect(result).toBe('test-instruction=skip-participant-cache')
+    })
+
+    test('should retrieve header with different casing (Baggage)', () => {
+      const headers = { Baggage: 'test-instruction=skip-participant-cache' }
+
+      const result = BaseQuotesModel._getNormalizedHeaderValue(headers, 'baggage')
+
+      expect(result).toBe('test-instruction=skip-participant-cache')
+    })
+
+    test('should retrieve header with mixed casing (bAgGaGe)', () => {
+      const headers = { bAgGaGe: 'test-instruction=skip-participant-cache' }
+
+      const result = BaseQuotesModel._getNormalizedHeaderValue(headers, 'BAGGAGE')
+
+      expect(result).toBe('test-instruction=skip-participant-cache')
+    })
+
+    test('should coerce array header value by joining with comma', () => {
+      const headers = { baggage: ['foo=bar', 'test-instruction=skip-participant-cache'] }
+
+      const result = BaseQuotesModel._getNormalizedHeaderValue(headers, 'baggage')
+
+      expect(result).toBe('foo=bar,test-instruction=skip-participant-cache')
+    })
+
+    test('should return undefined for missing header', () => {
+      const headers = { 'content-type': 'application/json' }
+
+      const result = BaseQuotesModel._getNormalizedHeaderValue(headers, 'baggage')
+
+      expect(result).toBeUndefined()
+    })
+
+    test('should return undefined for null/undefined headers', () => {
+      expect(BaseQuotesModel._getNormalizedHeaderValue(null, 'baggage')).toBeUndefined()
+      expect(BaseQuotesModel._getNormalizedHeaderValue(undefined, 'baggage')).toBeUndefined()
+    })
+
+    test('should return string coercion of non-string values', () => {
+      const headers = { 'x-custom': 12345 }
+
+      const result = BaseQuotesModel._getNormalizedHeaderValue(headers, 'x-custom')
+
+      expect(result).toBe('12345')
+    })
+  })
+
   describe('_parseBaggageHeader', () => {
     test('should parse comma-separated key=value pairs', () => {
       const baggage = 'foo=bar,test-instruction=skip-participant-cache,sample=123'
@@ -82,6 +137,35 @@ describe('BaseQuotesModel Tests -->', () => {
         'test-instruction': 'skip-participant-cache'
       })
     })
+
+    test('should handle array input by joining with comma', () => {
+      const baggage = ['foo=bar', 'test-instruction=skip-participant-cache', 'sample=123']
+
+      const result = BaseQuotesModel._parseBaggageHeader(baggage)
+
+      expect(result).toEqual({
+        foo: 'bar',
+        'test-instruction': 'skip-participant-cache',
+        sample: '123'
+      })
+    })
+
+    test('should handle single-element array', () => {
+      const baggage = ['test-instruction=skip-participant-cache']
+
+      const result = BaseQuotesModel._parseBaggageHeader(baggage)
+
+      expect(result).toEqual({
+        'test-instruction': 'skip-participant-cache'
+      })
+    })
+
+    test('should return empty object for null/undefined/empty input', () => {
+      expect(BaseQuotesModel._parseBaggageHeader(null)).toEqual({})
+      expect(BaseQuotesModel._parseBaggageHeader(undefined)).toEqual({})
+      expect(BaseQuotesModel._parseBaggageHeader('')).toEqual({})
+      expect(BaseQuotesModel._parseBaggageHeader([])).toEqual({})
+    })
   })
 
   describe('_shouldSkipParticipantCache', () => {
@@ -96,6 +180,47 @@ describe('BaseQuotesModel Tests -->', () => {
     test('should return false when baggage does not contain test instruction', () => {
       const headers = { baggage: 'foo=bar,sample=123' }
       expect(BaseQuotesModel._shouldSkipParticipantCache(headers)).toBe(false)
+    })
+
+    test('should handle case-insensitive header lookup (Baggage)', () => {
+      const headers = {
+        Baggage: 'test-instruction=skip-participant-cache'
+      }
+
+      expect(BaseQuotesModel._shouldSkipParticipantCache(headers)).toBe(true)
+    })
+
+    test('should handle mixed-case header lookup (bAgGaGe)', () => {
+      const headers = {
+        bAgGaGe: 'foo=bar,test-instruction=skip-participant-cache'
+      }
+
+      expect(BaseQuotesModel._shouldSkipParticipantCache(headers)).toBe(true)
+    })
+
+    test('should handle array header value (repeated header)', () => {
+      const headers = {
+        baggage: ['foo=bar', 'test-instruction=skip-participant-cache', 'sample=123']
+      }
+
+      expect(BaseQuotesModel._shouldSkipParticipantCache(headers)).toBe(true)
+    })
+
+    test('should handle single-element array header value', () => {
+      const headers = {
+        baggage: ['test-instruction=skip-participant-cache']
+      }
+
+      expect(BaseQuotesModel._shouldSkipParticipantCache(headers)).toBe(true)
+    })
+
+    test('should return false for empty headers', () => {
+      expect(BaseQuotesModel._shouldSkipParticipantCache({})).toBe(false)
+    })
+
+    test('should return false for null/undefined headers', () => {
+      expect(BaseQuotesModel._shouldSkipParticipantCache(null)).toBe(false)
+      expect(BaseQuotesModel._shouldSkipParticipantCache(undefined)).toBe(false)
     })
   })
 

--- a/test/unit/model/bulkQuotes.test.js
+++ b/test/unit/model/bulkQuotes.test.js
@@ -394,7 +394,7 @@ describe('BulkQuotesModel', () => {
 
             const result = await bulkQuotesModel.handleBulkQuoteRequest(mockData.headers, mockData.bulkQuotePostRequest, mockSpan)
 
-            const expectedValidateQuoteRequestArgs = [mockData.headers['fspiop-source'], mockData.headers['fspiop-destination'], mockData.bulkQuotePostRequest]
+            const expectedValidateQuoteRequestArgs = [mockData.headers['fspiop-source'], mockData.headers['fspiop-destination'], mockData.bulkQuotePostRequest, mockData.headers]
             expect(bulkQuotesModel.validateBulkQuoteRequest).toBeCalledWith(...expectedValidateQuoteRequestArgs)
             expect(mockSpan.getChild.mock.calls.length).toBe(1)
 

--- a/test/unit/model/fxQuotes.test.js
+++ b/test/unit/model/fxQuotes.test.js
@@ -166,7 +166,7 @@ describe('FxQuotesModel Tests -->', () => {
 
       await expect(fxQuotesModel.handleFxQuoteRequest(headers, request, span, request)).resolves.toBeUndefined()
 
-      expect(fxQuotesModel.validateFxQuoteRequest).toBeCalledWith(headers['fspiop-destination'], request)
+      expect(fxQuotesModel.validateFxQuoteRequest).toBeCalledWith(headers['fspiop-destination'], request, headers)
       expect(fxQuotesModel.forwardFxQuoteRequest).toBeCalledWith(headers, request, request, span.getChild())
     })
 
@@ -250,7 +250,7 @@ describe('FxQuotesModel Tests -->', () => {
       await expect(fxQuotesModel.handleFxQuoteRequest(headers, request, span, request))
         .resolves.toBeUndefined()
 
-      expect(fxQuotesModel.validateFxQuoteRequest).toBeCalledWith(headers['fspiop-destination'], request)
+      expect(fxQuotesModel.validateFxQuoteRequest).toBeCalledWith(headers['fspiop-destination'], request, headers)
       expect(fxQuotesModel.forwardFxQuoteRequest).toBeCalledWith(headers, request, request, span.getChild())
       expect(fxQuotesModel.handleException).toBeCalledWith(headers['fspiop-source'], request.conversionRequestId, expect.any(Error), headers, span.getChild())
       expect(span.getChild().finish).toBeCalledTimes(1)

--- a/test/unit/model/quotes.test.js
+++ b/test/unit/model/quotes.test.js
@@ -1326,7 +1326,7 @@ describe('QuotesModel', () => {
               quoteRequest: mockData.quoteRequest,
               span: mockSpan
             })
-            const expectedValidateQuoteRequestArgs = [mockData.headers['fspiop-source'], mockData.headers['fspiop-destination'], mockData.quoteRequest]
+            const expectedValidateQuoteRequestArgs = [mockData.headers['fspiop-source'], mockData.headers['fspiop-destination'], mockData.quoteRequest, mockData.headers]
             expect(quotesModel.validateQuoteRequest).toBeCalledWith(...expectedValidateQuoteRequestArgs)
             expect(mockSpan.getChild.mock.calls.length).toBe(1)
 
@@ -1438,7 +1438,7 @@ describe('QuotesModel', () => {
               span: mockSpan
             })
 
-            const expectedValidateQuoteRequestArgs = [mockData.headers['fspiop-source'], mockData.headers['fspiop-destination'], mockData.quoteRequest]
+            const expectedValidateQuoteRequestArgs = [mockData.headers['fspiop-source'], mockData.headers['fspiop-destination'], mockData.quoteRequest, mockData.headers]
             expect(quotesModel.validateQuoteRequest).toBeCalledWith(...expectedValidateQuoteRequestArgs)
             expect(mockSpan.getChild.mock.calls.length).toBe(1)
 
@@ -1473,7 +1473,7 @@ describe('QuotesModel', () => {
               span: mockSpan
             })
 
-            const expectedValidateQuoteRequestArgs = [mockData.headers['fspiop-source'], mockData.headers['fspiop-destination'], mockData.quoteRequest]
+            const expectedValidateQuoteRequestArgs = [mockData.headers['fspiop-source'], mockData.headers['fspiop-destination'], mockData.quoteRequest, mockData.headers]
             expect(quotesModel.validateQuoteRequest).toBeCalledWith(...expectedValidateQuoteRequestArgs)
             expect(mockSpan.getChild.mock.calls.length).toBe(1)
 


### PR DESCRIPTION
This pull request introduces a mechanism to bypass the participant cache in quote-related model operations when a specific instruction is present in the W3C `baggage` HTTP header. This feature is primarily intended for testing and debugging scenarios. The implementation includes new helper methods for parsing and detecting the cache bypass instruction, updates to relevant model methods to honor the bypass, and comprehensive unit tests to ensure correct behavior. Additionally, new participant cache bypass methods are added to the database layer.

**Participant cache bypass feature:**

* [`src/model/BaseQuotesModel.js`](diffhunk://#diff-d80b926e553fa7b6849c8541891cd89d7b85e295937606f041956845110eb25dR148-R206): Adds `_parseBaggageHeader` and `_shouldSkipParticipantCache` static helpers to detect the `test-instruction=skip-participant-cache` flag from the `baggage` header, and new `_getParticipant` and `_getParticipantByName` instance methods that call either cached or non-cached database methods based on this flag.
* `src/model/quotes.js`, `src/model/bulkQuotes.js`, `src/model/fxQuotes.js`: Refactors all participant lookups in quote validation and handling logic to use the new `_getParticipant` and `_getParticipantByName` helpers, and updates method signatures to accept the `headers` parameter. [[1]](diffhunk://#diff-5279fc369708a0f87ae15695811384dcd7a13ee54143c0f51771895e13d399d3L61-R61) [[2]](diffhunk://#diff-5279fc369708a0f87ae15695811384dcd7a13ee54143c0f51771895e13d399d3L100-R107) [[3]](diffhunk://#diff-5279fc369708a0f87ae15695811384dcd7a13ee54143c0f51771895e13d399d3L123-R123) [[4]](diffhunk://#diff-5279fc369708a0f87ae15695811384dcd7a13ee54143c0f51771895e13d399d3L134-R134) [[5]](diffhunk://#diff-5279fc369708a0f87ae15695811384dcd7a13ee54143c0f51771895e13d399d3L164-R164) [[6]](diffhunk://#diff-5279fc369708a0f87ae15695811384dcd7a13ee54143c0f51771895e13d399d3L194-R194) [[7]](diffhunk://#diff-5279fc369708a0f87ae15695811384dcd7a13ee54143c0f51771895e13d399d3L234-R239) [[8]](diffhunk://#diff-3553ae267987f39f7d33e828e3a4fa243cad0a5e42b5f949a0ad16edfdba2d0bL54-R61) [[9]](diffhunk://#diff-3553ae267987f39f7d33e828e3a4fa243cad0a5e42b5f949a0ad16edfdba2d0bL81-R81) [[10]](diffhunk://#diff-b4017adad890ac2371ceae5b3212990557a547cac13c4405ae5eff8f406d1033L50-R50) [[11]](diffhunk://#diff-b4017adad890ac2371ceae5b3212990557a547cac13c4405ae5eff8f406d1033L68-R68) [[12]](diffhunk://#diff-b4017adad890ac2371ceae5b3212990557a547cac13c4405ae5eff8f406d1033L184-R184)

**Database layer enhancements:**

* `src/data/database.js`, `src/data/cachedDatabase.js`: Adds `getParticipantNoCache` and `getParticipantByNameNoCache` methods to support explicit non-cached participant lookups, and exposes them in the cached database subclass. [[1]](diffhunk://#diff-015b7431b72c0488057e25e01247148a87116c4e0b66b9a4baf51df6d58e5422R409-R428) [[2]](diffhunk://#diff-83fa7f2b5e6ce1315cef52d96f081e3eb1d6704e97981fe6a284449442e63ec9R99-R106)

**Testing improvements:**

* [`test/unit/model/BaseQuotesModel.test.js`](diffhunk://#diff-636bb6cf8805faa27ebdf23995ec86d09c4484f9db79e486665b29d0886e75fcR61-R150): Adds thorough unit tests for baggage header parsing, cache bypass detection, and the new participant retrieval helpers.
* `test/unit/model/quotes.test.js`, `test/unit/model/bulkQuotes.test.js`, `test/unit/model/fxQuotes.test.js`: Updates existing tests to verify that the new `headers` parameter is passed and that the appropriate methods are called. [[1]](diffhunk://#diff-4339af044cf67bbf6777e0d4531291100ad3e5f9a93e6b4c1f694174d77af576L1329-R1329) [[2]](diffhunk://#diff-b0c1fd2e1d08c98baf160f291313c03a8d6a9ff3227c9658911980464fedbb6bL397-R397) [[3]](diffhunk://#diff-53897705342880a7b4abef98125475a195ff97b4909a81df4539a3efeef8c69eL169-R169) [[4]](diffhunk://#diff-53897705342880a7b4abef98125475a195ff97b4909a81df4539a3efeef8c69eL253-R253)

**Audit configuration update:**

* [`audit-ci.jsonc`](diffhunk://#diff-4ede69da2a1704e53e08b8d647a315c202f037cc9277f16c94176d9622d261c6L7-R11): Expands the allowlist to include additional advisories.